### PR TITLE
Create FirstOptaneTest

### DIFF
--- a/Workloads/FirstOptaneTest
+++ b/Workloads/FirstOptaneTest
@@ -1,0 +1,28 @@
+[global]
+name= FirstOptaneTest
+ioengine=pvsync2
+hipri
+direct=1
+buffered=0
+size=100%
+randrepeat=0
+time_based
+ramp_time=0
+norandommap
+refill_buffers
+log_avg_msec=1000
+log_max_value=1
+group_reporting
+percentile_list=1.0:25.0:50.0:75.0:90.0:99.0:99.9:99.99:99.999:99.9999:99.99999:99.999999:100.0
+filename=/dev/nvme0n1
+
+[rd_rnd_qd_1_4k_1w]
+bs=4k
+iodepth=1
+numjobs=1
+rw=randread
+#cpus_allowed=0-17 - dependent on NUMA configuration
+runtime=300
+write_bw_log=bw_rd_rnd_qd_1_4k_1w
+write_iops_log=iops_rd_rnd_qd_1_4k_1w
+write_lat_log=lat_rd_rnd_qd_1_4k_1w


### PR DESCRIPTION
This is a good first script to determine a sync test with a QD of 1. It assumes:
usage of poll_queues or polled devices
usage of a multi NUMA Node system otherwise you don't need cpus_allowed=
For more info - please see - https://itpeernetwork.intel.com/tuning-performance-intel-optane-ssds-linux-operating-systems/